### PR TITLE
Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additionally, this is all streamlined into a Raspoberry Pi (pictured above) with
 #####Software Dependencies: 
 * aircrack-ng
 * Tkinter python library (python-tk in debian)
-* hosapd
+* hostapd
 * dnsmasq
 * Network Manager, specifically nmcli
 


### PR DESCRIPTION
A small / nitpicky change to correct a typo in the "#####Software Dependencies:" section of the README.md:

Line 14: \* hosapd

Should be listed as "hostapd".
