### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 rickmote
 ========
 
-##The Rickmote Controller: Hijack TVs using Google Chromecast
+## The Rickmote Controller: Hijack TVs using Google Chromecast
 ![The Rickmote Controller](docs/Rickmote.jpg)
 
 The Rickmote is a Python program for Hijacking Chromecasts and playing arbitrary video to their connected TVs. Full details on how the hack works will be provided at the talk "Rickrolling your Neighbors with Google Chromecast" at HOPE X in New York. See you there!
 
 Additionally, this is all streamlined into a Raspberry Pi (pictured above) with details to come soon at BlackHat USA 2014's Tools Arsenal! If you just can't wait and want to try pranking your friends right away, here are the vital ingredients:
 
-#####Software Dependencies: 
+##### Software Dependencies: 
 * aircrack-ng
 * Tkinter python library (python-tk in debian)
 * hostapd
 * dnsmasq
 * Network Manager, specifically nmcli
 
-#####3D Printed Case:
+##### 3D Printed Case:
 Download the 3D models for the slick Rickmote 3D printed case here at Thingiverse
 http://www.thingiverse.com/thing:398100
 
-#####Setup Assumptions:
+##### Setup Assumptions:
 The Rickmote Controller needs to pull a lot of Wi-Fi shenanigans in order to automate the hack. For best results, you may want to try using Kali Linux as it has the easiest setup for wireless drivers that support injection. Also note that we are actively working on reducing these assumptions! Sorry it's so specific in the meantime.
 * Three wireless interfaces.
     * wlan0 is a client interface that is set to Managed mode


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
